### PR TITLE
コメント欄の画像が表示されない問題の解決

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,7 +2,7 @@
   <% if current_user.image? %>
     <%= image_tag current_user.image.thumb40.url, class: 'icon' %>
   <% else %>
-    <%= image_tag "/assets/default.png", class: 'default-icon-md' %>
+    <%= image_tag asset_path("default.png"), class: 'default-icon-md' %>
   <% end %>
   <span>コメントを入力</span>
 </div>

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -7,7 +7,7 @@
             <% if comment.user.image? %>
               <%= image_tag comment.user.image.thumb24.url, class: 'icon' %>
             <% else %>
-              <%= image_tag "/assets/default.png", class: 'default-icon-sm' %>
+              <%= image_tag asset_path("default.png"), class: 'default-icon-sm' %>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
デフォルトはassetsから取り出すように指定