### PR TITLE
投稿閲覧時のユーザー情報欄のデザイン改善 close #8

### DIFF
--- a/app/assets/stylesheets/techniques.scss
+++ b/app/assets/stylesheets/techniques.scss
@@ -55,22 +55,24 @@ aside {
   z-index: 0;
   .user {
     .card-body {
-      display: flex;
-      justify-content: space-between;
-      flex-wrap: wrap;
       .user-info {
         display: flex;
-        margin-bottom: 10px;
-        .user-avatar {
-          margin-right: 5px;
-        }
-        .user-name {
+        justify-content: space-between;
+        flex-wrap: wrap;
+        .user-link {
           display: flex;
-          align-items: center;
-          a {
-            font-weight: bold;
-            text-decoration: none;
-            color: black;
+          margin-bottom: 10px;
+          .user-avatar {
+            margin-right: 5px;
+          }
+          .user-name {
+            display: flex;
+            align-items: center;
+            a {
+              font-weight: bold;
+              text-decoration: none;
+              color: black;
+            }
           }
         }
         .follow-button {

--- a/app/views/techniques/show.html.erb
+++ b/app/views/techniques/show.html.erb
@@ -100,23 +100,25 @@
       <div class="card user">
         <div class="card-body">
           <div class="user-info">
-            <div class="user-avatar">
-              <%= link_to user_path(@user) do %>
-                <% if @user.image? %>
-                  <%= image_tag @user.image.thumb40.url, class: 'icon' %>
-                <% else %>
-                  <%= image_tag asset_path("default.png"), class: 'default-icon-md' %>
+            <div class="user-link">
+              <div class="user-avatar">
+                <%= link_to user_path(@user) do %>
+                  <% if @user.image? %>
+                    <%= image_tag @user.image.thumb40.url, class: 'icon' %>
+                  <% else %>
+                    <%= image_tag asset_path("default.png"), class: 'default-icon-md' %>
+                  <% end %>
                 <% end %>
-              <% end %>
+              </div>
+              <div class="user-name">
+                <%= link_to user_path(@user) do %>
+                  <%= @user.name %>
+                <% end %>
+              </div>
             </div>
-            <div class="user-name">
-              <%= link_to user_path(@user) do %>
-                <%= @user.name %>
-              <% end %>
+            <div class="follow-button">
+              <%= render 'relationships/follow_button', user: @user %>
             </div>
-          </div>
-          <div class="follow-button">
-            <%= render 'relationships/follow_button', user: @user %>
           </div>
           <div class="user-profile">
             <%= simple_format(@user.profile) %>


### PR DESCRIPTION
ユーザー画像、ユーザー名とフォローボタンを一列目に、
プロフィール情報を二列目に来るようにしました。
ユーザー名が短い時に全て１列に並んでしまう問題は改善されました。