### PR TITLE
cibuilds/awsイメージを追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@1.1.0
   node: circleci/node@2
-  aws-cli: circleci/aws-cli@2.0.0
 
 jobs:
   build:
@@ -51,6 +50,7 @@ jobs:
   deploy:
     docker:
       - image: circleci/ruby:2.7.1-node-browsers
+      - image: cibuilds/aws
     environment:
       BUNDLER_VERSION: 2.1.4 
     steps:


### PR DESCRIPTION
awsコマンドが使用できない為。